### PR TITLE
Updates for central production

### DIFF
--- a/Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stauXXX_lspXXX_ctauXXXmm.py
+++ b/Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stauXXX_lspXXX_ctauXXXmm.py
@@ -3,7 +3,7 @@ COM_ENERGY = 13000. # GeV
 MASS_POINT = STAU_MASS_XXX   # GeV
 MASS_LSP = LSP_MASS_XXX  # GeV
 # https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SUSYCrossSections13TeVslepslep#NLO_NLL_any_single_generation_su
-CROSS_SECTION = XSEC_XXX # pb
+#CROSS_SECTION = XSEC_XXX # pb
 CTAU0_POINT = CTAU_XXX # mm
 PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
 PARTICLE_FILE = ("data/particles_stau_mstau{}GeV_mlsp{}GeV_ctau{}mm.txt".format(MASS_POINT, MASS_LSP, CTAU0_POINT))
@@ -131,7 +131,7 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
      pythiaPylistVerbosity = cms.untracked.int32(1),
      filterEfficiency = cms.untracked.double(1.0),
      pythiaHepMCVerbosity = cms.untracked.bool(False),
-     crossSection = cms.untracked.double(CROSS_SECTION),
+     #crossSection = cms.untracked.double(CROSS_SECTION),
      comEnergy = cms.double(COM_ENERGY),
      GridpackPath =  cms.string(GRIDPACK),
      ConfigDescription = cms.string('%s_%i_%i_%f' % (model, MASS_POINT, MASS_LSP, CTAU0_POINT)),

--- a/python/SUS-RunIISummer20UL18HLT_cfg.py
+++ b/python/SUS-RunIISummer20UL18HLT_cfg.py
@@ -2,7 +2,7 @@
 # using: 
 # Revision: 1.19 
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
-# with command line options: --python_filename /afs/cern.ch/work/m/myshched/GEN-STAU/LLSTauProduction20UL18_pythia_100cm/LLSTauProduction/script/../python/SUS-RunIISummer20UL18HLT_cfg.py --eventcontent RAWSIM --outputCommand keep *_genParticlePlusGeant_*_* --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce --datatier GEN-SIM-RAW --fileout file:SUS-RunIISummer20UL18HLT-LLStau.root --conditions 102X_upgrade2018_realistic_v15 --customise_commands process.source.bypassVersionCheck = cms.untracked.bool(True) --step HLT:2018v32 --geometry DB:Extended --filein file:SUS-RunIIAutumn18DRPremix-LLStau.root --era Run2_2018 --no_exec --mc -n 20
+# with command line options: --python_filename /afs/cern.ch/work/s/sobhatta/private/LongLivedStaus/test_forMCrequest_2/LLSTauProduction/script/../python/SUS-RunIISummer20UL18HLT_cfg.py --eventcontent RAWSIM --outputCommand keep *_genParticlePlusGeant_*_*,keep *_packedGenParticlePlusGeant_*_*,keep *_prunedGenParticlePlusGeant_*_* --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeKeep,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeProduce --datatier GEN-SIM-RAW --fileout file:SUS-RunIISummer20UL18HLT-LLStau.root --conditions 102X_upgrade2018_realistic_v15 --customise_commands process.source.bypassVersionCheck = cms.untracked.bool(True) --step HLT:2018v32 --geometry DB:Extended --filein file:SUS-RunIIAutumn18DRPremix-LLStau.root --era Run2_2018 --no_exec --mc -n 20
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.Eras import eras
@@ -63,6 +63,8 @@ process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '102X_upgrade2018_realistic_v15', '')
 process.RAWSIMoutput.outputCommands.append('keep *_genParticlePlusGeant_*_*')
+process.RAWSIMoutput.outputCommands.append('keep *_packedGenParticlePlusGeant_*_*')
+process.RAWSIMoutput.outputCommands.append('keep *_prunedGenParticlePlusGeant_*_*')
 
 # Path and EndPath definitions
 process.endjob_step = cms.EndPath(process.endOfProcess)
@@ -83,13 +85,13 @@ from Configuration.DataProcessing.Utils import addMonitoring
 #call to customisation function addMonitoring imported from Configuration.DataProcessing.Utils
 process = addMonitoring(process)
 
-# Automatic addition of the customisation function from SimG4Core.CustomPhysics.genParticlePlusGeant
-from SimG4Core.CustomPhysics.genParticlePlusGeant import customizeKeep,customizeProduce 
+# Automatic addition of the customisation function from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
+from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi import customizeKeep,customizeProduce 
 
-#call to customisation function customizeKeep imported from SimG4Core.CustomPhysics.genParticlePlusGeant
+#call to customisation function customizeKeep imported from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
 process = customizeKeep(process)
 
-#call to customisation function customizeProduce imported from SimG4Core.CustomPhysics.genParticlePlusGeant
+#call to customisation function customizeProduce imported from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
 process = customizeProduce(process)
 
 # Automatic addition of the customisation function from HLTrigger.Configuration.customizeHLTforMC

--- a/python/SUS-RunIISummer20UL18MiniAODv2_cfg.py
+++ b/python/SUS-RunIISummer20UL18MiniAODv2_cfg.py
@@ -2,7 +2,7 @@
 # using: 
 # Revision: 1.19 
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
-# with command line options: --python_filename /afs/cern.ch/work/m/myshched/GEN-STAU/LLSTauProduction20UL18_pythia_100cm/LLSTauProduction/script/../python/SUS-RunIISummer20UL18MiniAODv2_cfg.py --eventcontent MINIAODSIM --outputCommand keep *_genParticlePlusGeant_*_* --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce --datatier MINIAODSIM --fileout file:SUS-RunIISummer20UL18MiniAODv2-LLStau.root --conditions 106X_upgrade2018_realistic_v16_L1v1 --step PAT --procModifiers run2_miniAOD_UL --geometry DB:Extended --filein file:SUS-RunIISummer20UL18RECO-LLStau.root --era Run2_2018 --runUnscheduled --no_exec --mc -n 20
+# with command line options: --python_filename /afs/cern.ch/work/s/sobhatta/private/LongLivedStaus/test_forMCrequest_2/LLSTauProduction/script/../python/SUS-RunIISummer20UL18MiniAODv2_cfg.py --eventcontent MINIAODSIM --outputCommand keep *_genParticlePlusGeant_*_*,keep *_packedGenParticlePlusGeant_*_*,keep *_prunedGenParticlePlusGeant_*_* --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeKeep,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeProduce --datatier MINIAODSIM --fileout file:SUS-RunIISummer20UL18MiniAODv2-LLStau.root --conditions 106X_upgrade2018_realistic_v16_L1v1 --step PAT --procModifiers run2_miniAOD_UL --geometry DB:Extended --filein file:SUS-RunIISummer20UL18RECO-LLStau.root --era Run2_2018 --runUnscheduled --no_exec --mc -n 20
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
@@ -118,6 +118,8 @@ process.MINIAODSIMoutput = cms.OutputModule("PoolOutputModule",
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '106X_upgrade2018_realistic_v16_L1v1', '')
 process.MINIAODSIMoutput.outputCommands.append('keep *_genParticlePlusGeant_*_*')
+process.MINIAODSIMoutput.outputCommands.append('keep *_packedGenParticlePlusGeant_*_*')
+process.MINIAODSIMoutput.outputCommands.append('keep *_prunedGenParticlePlusGeant_*_*')
 
 # Path and EndPath definitions
 process.Flag_trackingFailureFilter = cms.Path(process.goodVertices+process.trackingFailureFilter)
@@ -166,13 +168,13 @@ from Configuration.DataProcessing.Utils import addMonitoring
 #call to customisation function addMonitoring imported from Configuration.DataProcessing.Utils
 process = addMonitoring(process)
 
-# Automatic addition of the customisation function from SimG4Core.CustomPhysics.genParticlePlusGeant
-from SimG4Core.CustomPhysics.genParticlePlusGeant import customizeKeep,customizeProduce 
+# Automatic addition of the customisation function from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
+from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi import customizeKeep,customizeProduce 
 
-#call to customisation function customizeKeep imported from SimG4Core.CustomPhysics.genParticlePlusGeant
+#call to customisation function customizeKeep imported from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
 process = customizeKeep(process)
 
-#call to customisation function customizeProduce imported from SimG4Core.CustomPhysics.genParticlePlusGeant
+#call to customisation function customizeProduce imported from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
 process = customizeProduce(process)
 
 # End of customisation functions

--- a/python/SUS-RunIISummer20UL18RECO_cfg.py
+++ b/python/SUS-RunIISummer20UL18RECO_cfg.py
@@ -2,7 +2,7 @@
 # using: 
 # Revision: 1.19 
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
-# with command line options: --python_filename /afs/cern.ch/work/m/myshched/GEN-STAU/LLSTauProduction20UL18_pythia_100cm/LLSTauProduction/script/../python/SUS-RunIISummer20UL18RECO_cfg.py --eventcontent AODSIM --outputCommand keep *_genParticlePlusGeant_*_* --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce --datatier AODSIM --fileout file:SUS-RunIISummer20UL18RECO-LLStau.root --conditions 106X_upgrade2018_realistic_v11_L1v1 --step RAW2DIGI,L1Reco,RECO,RECOSIM,EI --geometry DB:Extended --filein file:SUS-RunIISummer20UL18HLT-LLStau.root --era Run2_2018 --runUnscheduled --no_exec --mc -n 20
+# with command line options: --python_filename /afs/cern.ch/work/s/sobhatta/private/LongLivedStaus/test_forMCrequest_2/LLSTauProduction/script/../python/SUS-RunIISummer20UL18RECO_cfg.py --eventcontent AODSIM --outputCommand keep *_genParticlePlusGeant_*_*,keep *_packedGenParticlePlusGeant_*_*,keep *_prunedGenParticlePlusGeant_*_* --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeKeep,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeProduce --datatier AODSIM --fileout file:SUS-RunIISummer20UL18RECO-LLStau.root --conditions 106X_upgrade2018_realistic_v11_L1v1 --step RAW2DIGI,L1Reco,RECO,RECOSIM,EI --geometry DB:Extended --filein file:SUS-RunIISummer20UL18HLT-LLStau.root --era Run2_2018 --runUnscheduled --no_exec --mc -n 20
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
@@ -66,6 +66,8 @@ process.AODSIMoutput = cms.OutputModule("PoolOutputModule",
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '106X_upgrade2018_realistic_v11_L1v1', '')
 process.AODSIMoutput.outputCommands.append('keep *_genParticlePlusGeant_*_*')
+process.AODSIMoutput.outputCommands.append('keep *_packedGenParticlePlusGeant_*_*')
+process.AODSIMoutput.outputCommands.append('keep *_prunedGenParticlePlusGeant_*_*')
 
 # Path and EndPath definitions
 process.raw2digi_step = cms.Path(process.RawToDigi)
@@ -89,13 +91,13 @@ from Configuration.DataProcessing.Utils import addMonitoring
 #call to customisation function addMonitoring imported from Configuration.DataProcessing.Utils
 process = addMonitoring(process)
 
-# Automatic addition of the customisation function from SimG4Core.CustomPhysics.genParticlePlusGeant
-from SimG4Core.CustomPhysics.genParticlePlusGeant import customizeKeep,customizeProduce 
+# Automatic addition of the customisation function from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
+from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi import customizeKeep,customizeProduce 
 
-#call to customisation function customizeKeep imported from SimG4Core.CustomPhysics.genParticlePlusGeant
+#call to customisation function customizeKeep imported from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
 process = customizeKeep(process)
 
-#call to customisation function customizeProduce imported from SimG4Core.CustomPhysics.genParticlePlusGeant
+#call to customisation function customizeProduce imported from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
 process = customizeProduce(process)
 
 # End of customisation functions

--- a/python/SUS-RunIISummer20UL18wmLHEGEN-stau100_lsp1_ctau100mm_cfg.py
+++ b/python/SUS-RunIISummer20UL18wmLHEGEN-stau100_lsp1_ctau100mm_cfg.py
@@ -2,7 +2,7 @@
 # using: 
 # Revision: 1.19 
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
-# with command line options: Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stau100_lsp1_ctau100mm.py --python_filename /afs/cern.ch/work/m/myshched/GEN-STAU/LLSTauProduction20UL18_pythia_100cm/LLSTauProduction/script/../python/SUS-RunIISummer20UL18wmLHEGEN-stau100_lsp1_ctau100mm_cfg.py --eventcontent RAWSIM --outputCommand keep *_genParticlePlusGeant_*_* --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/Exotica_HSCP_SIM_cfi.customise,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce --datatier GEN-SIM --fileout file:SUS-RunIISummer20UL18wmLHEGEN-LLStau.root --conditions 106X_upgrade2018_realistic_v11_L1v1 --beamspot Realistic25ns13TeVEarly2018Collision --customise_commands process.RandomNumberGeneratorService.externalLHEProducer.initialSeed=int(1)\nprocess.source.numberEventsInLuminosityBlock=cms.untracked.uint32(100) --step GEN,SIM --geometry DB:Extended --era Run2_2018 --no_exec --mc -n 20
+# with command line options: Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stau100_lsp1_ctau100mm.py --python_filename /afs/cern.ch/work/s/sobhatta/private/LongLivedStaus/test_forMCrequest_2/LLSTauProduction/script/../python/SUS-RunIISummer20UL18wmLHEGEN-stau100_lsp1_ctau100mm_cfg.py --eventcontent RAWSIM --outputCommand keep *_genParticlePlusGeant_*_*,keep *_packedGenParticlePlusGeant_*_*,keep *_prunedGenParticlePlusGeant_*_* --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/Exotica_HSCP_SIM_cfi.customise,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeKeep,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeProduce --datatier GEN-SIM --fileout file:SUS-RunIISummer20UL18wmLHEGEN-LLStau.root --conditions 106X_upgrade2018_realistic_v11_L1v1 --beamspot Realistic25ns13TeVEarly2018Collision --customise_commands process.RandomNumberGeneratorService.externalLHEProducer.initialSeed=int(1)\nprocess.source.numberEventsInLuminosityBlock=cms.untracked.uint32(100) --step GEN,SIM --geometry DB:Extended --era Run2_2018 --no_exec --mc -n 20
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
@@ -69,6 +69,8 @@ process.genstepfilter.triggerConditions=cms.vstring("generation_step")
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '106X_upgrade2018_realistic_v11_L1v1', '')
 process.RAWSIMoutput.outputCommands.append('keep *_genParticlePlusGeant_*_*')
+process.RAWSIMoutput.outputCommands.append('keep *_packedGenParticlePlusGeant_*_*')
+process.RAWSIMoutput.outputCommands.append('keep *_prunedGenParticlePlusGeant_*_*')
 
 process.generator = cms.EDFilter("Pythia8GeneratorFilter",
     ConfigDescription = cms.string('TStauStauLL_100_1_100.000000'),
@@ -134,7 +136,6 @@ process.generator = cms.EDFilter("Pythia8GeneratorFilter",
     ),
     SLHATableForPythia8 = cms.string('\nBLOCK MASS  # Mass Spectrum\n# PDG code           mass       particle\n   1000001     1.00000000E+05   # ~d_L\n   2000001     1.00000000E+05   # ~d_R\n   1000002     1.00000000E+05   # ~u_L\n   2000002     1.00000000E+05   # ~u_R\n   1000003     1.00000000E+05   # ~s_L\n   2000003     1.00000000E+05   # ~s_R\n   1000004     1.00000000E+05   # ~c_L\n   2000004     1.00000000E+05   # ~c_R\n   1000005     1.00000000E+05   # ~b_1\n   2000005     1.00000000E+05   # ~b_2\n   1000006     1.00000000E+05   # ~t_1\n   2000006     1.00000000E+05   # ~t_2\n   1000011     1.00000000E+05   # ~e_L\n   2000011     1.00000000E+05   # ~e_R\n   1000012     1.00000000E+05   # ~nu_eL\n   1000013     1.00000000E+05   # ~mu_L\n   2000013     1.00000000E+05   # ~mu_R\n   1000014     1.00000000E+05   # ~nu_muL\n   1000015     1.000000e+02          # ~tau_1\n   2000015     1.00000000E+05   # ~tau_2\n   1000016     1.00000000E+05   # ~nu_tauL\n   1000021     1.00000000E+05   # ~g\n   1000022     1.000000e+00           # ~chi_10\n   1000023     1.00000000E+05   # ~chi_20\n   1000025     1.00000000E+05   # ~chi_30\n   1000035     1.00000000E+05   # ~chi_40\n   1000024     1.00000000E+05   # ~chi_1+\n   1000037     1.00000000E+05   # ~chi_2+\n\n# DECAY TABLE\n#         PDG            Width\nDECAY   1000001     0.00000000E+00   # sdown_L decays\nDECAY   2000001     0.00000000E+00   # sdown_R decays\nDECAY   1000002     0.00000000E+00   # sup_L decays\nDECAY   2000002     0.00000000E+00   # sup_R decays\nDECAY   1000003     0.00000000E+00   # sstrange_L decays\nDECAY   2000003     0.00000000E+00   # sstrange_R decays\nDECAY   1000004     0.00000000E+00   # scharm_L decays\nDECAY   2000004     0.00000000E+00   # scharm_R decays\nDECAY   1000005     0.00000000E+00   # sbottom1 decays\nDECAY   2000005     0.00000000E+00   # sbottom2 decays\nDECAY   1000006     0.00000000E+00   # stop1 decays\nDECAY   2000006     0.00000000E+00   # stop2 decays\nDECAY   1000011     0.00000000E+00   # selectron_L decays\nDECAY   2000011     0.00000000E+00   # selectron_R decays\nDECAY   1000012     0.0000000E+00    # snu_elL decays\nDECAY   1000013     0.00000000E+00   # smuon_L decays\nDECAY   2000013     0.00000000E+00   # smuon_R decays\nDECAY   1000014     0.00000000E+00   # snu_muL decays\nDECAY   1000015     1.973270e-15           # stau_1 decays\n    1.00000000E+00    2    1000022    15\nDECAY   2000015     0.00000000E+00   # stau_2 decays\nDECAY   1000016     0.00000000E+00   # snu_tauL decays\nDECAY   1000021     0.00000000E+00   # gluino decays\nDECAY   1000022     0.00000000E+00   # neutralino1 decays\nDECAY   1000023     0.00000000E+00   # neutralino2 decays\nDECAY   1000024     0.00000000E+00   # chargino1+ decays\nDECAY   1000025     0.00000000E+00   # neutralino3 decays\nDECAY   1000035     0.00000000E+00   # neutralino4 decays\nDECAY   1000037     0.00000000E+00   # chargino2+ decays\n'),
     comEnergy = cms.double(13000.0),
-    crossSection = cms.untracked.double(0.3657),
     filterEfficiency = cms.untracked.double(1.0),
     hscpFlavor = cms.untracked.string('stau'),
     massPoint = cms.untracked.int32(100),
@@ -176,13 +177,13 @@ from SimG4Core.CustomPhysics.Exotica_HSCP_SIM_cfi import customise
 #call to customisation function customise imported from SimG4Core.CustomPhysics.Exotica_HSCP_SIM_cfi
 process = customise(process)
 
-# Automatic addition of the customisation function from SimG4Core.CustomPhysics.genParticlePlusGeant
-from SimG4Core.CustomPhysics.genParticlePlusGeant import customizeKeep,customizeProduce 
+# Automatic addition of the customisation function from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
+from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi import customizeKeep,customizeProduce 
 
-#call to customisation function customizeKeep imported from SimG4Core.CustomPhysics.genParticlePlusGeant
+#call to customisation function customizeKeep imported from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
 process = customizeKeep(process)
 
-#call to customisation function customizeProduce imported from SimG4Core.CustomPhysics.genParticlePlusGeant
+#call to customisation function customizeProduce imported from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
 process = customizeProduce(process)
 
 # End of customisation functions

--- a/python/SUS-RunIISummer20UL18wmLHEGEN-stau250_lsp1_ctau100mm_cfg.py
+++ b/python/SUS-RunIISummer20UL18wmLHEGEN-stau250_lsp1_ctau100mm_cfg.py
@@ -2,7 +2,7 @@
 # using: 
 # Revision: 1.19 
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
-# with command line options: Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stau250_lsp1_ctau100mm.py --python_filename /afs/cern.ch/work/m/myshched/GEN-STAU/LLSTauProduction20UL18_pythia_100cm/LLSTauProduction/script/../python/SUS-RunIISummer20UL18wmLHEGEN-stau250_lsp1_ctau100mm_cfg.py --eventcontent RAWSIM --outputCommand keep *_genParticlePlusGeant_*_* --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/Exotica_HSCP_SIM_cfi.customise,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce --datatier GEN-SIM --fileout file:SUS-RunIISummer20UL18wmLHEGEN-LLStau.root --conditions 106X_upgrade2018_realistic_v11_L1v1 --beamspot Realistic25ns13TeVEarly2018Collision --customise_commands process.RandomNumberGeneratorService.externalLHEProducer.initialSeed=int(1)\nprocess.source.numberEventsInLuminosityBlock=cms.untracked.uint32(100) --step GEN,SIM --geometry DB:Extended --era Run2_2018 --no_exec --mc -n 20
+# with command line options: Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stau250_lsp1_ctau100mm.py --python_filename /afs/cern.ch/work/s/sobhatta/private/LongLivedStaus/test_forMCrequest_2/LLSTauProduction/script/../python/SUS-RunIISummer20UL18wmLHEGEN-stau250_lsp1_ctau100mm_cfg.py --eventcontent RAWSIM --outputCommand keep *_genParticlePlusGeant_*_*,keep *_packedGenParticlePlusGeant_*_*,keep *_prunedGenParticlePlusGeant_*_* --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/Exotica_HSCP_SIM_cfi.customise,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeKeep,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeProduce --datatier GEN-SIM --fileout file:SUS-RunIISummer20UL18wmLHEGEN-LLStau.root --conditions 106X_upgrade2018_realistic_v11_L1v1 --beamspot Realistic25ns13TeVEarly2018Collision --customise_commands process.RandomNumberGeneratorService.externalLHEProducer.initialSeed=int(1)\nprocess.source.numberEventsInLuminosityBlock=cms.untracked.uint32(100) --step GEN,SIM --geometry DB:Extended --era Run2_2018 --no_exec --mc -n 20
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
@@ -69,6 +69,8 @@ process.genstepfilter.triggerConditions=cms.vstring("generation_step")
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '106X_upgrade2018_realistic_v11_L1v1', '')
 process.RAWSIMoutput.outputCommands.append('keep *_genParticlePlusGeant_*_*')
+process.RAWSIMoutput.outputCommands.append('keep *_packedGenParticlePlusGeant_*_*')
+process.RAWSIMoutput.outputCommands.append('keep *_prunedGenParticlePlusGeant_*_*')
 
 process.generator = cms.EDFilter("Pythia8GeneratorFilter",
     ConfigDescription = cms.string('TStauStauLL_250_1_100.000000'),
@@ -134,7 +136,6 @@ process.generator = cms.EDFilter("Pythia8GeneratorFilter",
     ),
     SLHATableForPythia8 = cms.string('\nBLOCK MASS  # Mass Spectrum\n# PDG code           mass       particle\n   1000001     1.00000000E+05   # ~d_L\n   2000001     1.00000000E+05   # ~d_R\n   1000002     1.00000000E+05   # ~u_L\n   2000002     1.00000000E+05   # ~u_R\n   1000003     1.00000000E+05   # ~s_L\n   2000003     1.00000000E+05   # ~s_R\n   1000004     1.00000000E+05   # ~c_L\n   2000004     1.00000000E+05   # ~c_R\n   1000005     1.00000000E+05   # ~b_1\n   2000005     1.00000000E+05   # ~b_2\n   1000006     1.00000000E+05   # ~t_1\n   2000006     1.00000000E+05   # ~t_2\n   1000011     1.00000000E+05   # ~e_L\n   2000011     1.00000000E+05   # ~e_R\n   1000012     1.00000000E+05   # ~nu_eL\n   1000013     1.00000000E+05   # ~mu_L\n   2000013     1.00000000E+05   # ~mu_R\n   1000014     1.00000000E+05   # ~nu_muL\n   1000015     2.500000e+02          # ~tau_1\n   2000015     1.00000000E+05   # ~tau_2\n   1000016     1.00000000E+05   # ~nu_tauL\n   1000021     1.00000000E+05   # ~g\n   1000022     1.000000e+00           # ~chi_10\n   1000023     1.00000000E+05   # ~chi_20\n   1000025     1.00000000E+05   # ~chi_30\n   1000035     1.00000000E+05   # ~chi_40\n   1000024     1.00000000E+05   # ~chi_1+\n   1000037     1.00000000E+05   # ~chi_2+\n\n# DECAY TABLE\n#         PDG            Width\nDECAY   1000001     0.00000000E+00   # sdown_L decays\nDECAY   2000001     0.00000000E+00   # sdown_R decays\nDECAY   1000002     0.00000000E+00   # sup_L decays\nDECAY   2000002     0.00000000E+00   # sup_R decays\nDECAY   1000003     0.00000000E+00   # sstrange_L decays\nDECAY   2000003     0.00000000E+00   # sstrange_R decays\nDECAY   1000004     0.00000000E+00   # scharm_L decays\nDECAY   2000004     0.00000000E+00   # scharm_R decays\nDECAY   1000005     0.00000000E+00   # sbottom1 decays\nDECAY   2000005     0.00000000E+00   # sbottom2 decays\nDECAY   1000006     0.00000000E+00   # stop1 decays\nDECAY   2000006     0.00000000E+00   # stop2 decays\nDECAY   1000011     0.00000000E+00   # selectron_L decays\nDECAY   2000011     0.00000000E+00   # selectron_R decays\nDECAY   1000012     0.0000000E+00    # snu_elL decays\nDECAY   1000013     0.00000000E+00   # smuon_L decays\nDECAY   2000013     0.00000000E+00   # smuon_R decays\nDECAY   1000014     0.00000000E+00   # snu_muL decays\nDECAY   1000015     1.973270e-15           # stau_1 decays\n    1.00000000E+00    2    1000022    15\nDECAY   2000015     0.00000000E+00   # stau_2 decays\nDECAY   1000016     0.00000000E+00   # snu_tauL decays\nDECAY   1000021     0.00000000E+00   # gluino decays\nDECAY   1000022     0.00000000E+00   # neutralino1 decays\nDECAY   1000023     0.00000000E+00   # neutralino2 decays\nDECAY   1000024     0.00000000E+00   # chargino1+ decays\nDECAY   1000025     0.00000000E+00   # neutralino3 decays\nDECAY   1000035     0.00000000E+00   # neutralino4 decays\nDECAY   1000037     0.00000000E+00   # chargino2+ decays\n'),
     comEnergy = cms.double(13000.0),
-    crossSection = cms.untracked.double(0.01292),
     filterEfficiency = cms.untracked.double(1.0),
     hscpFlavor = cms.untracked.string('stau'),
     massPoint = cms.untracked.int32(250),
@@ -176,13 +177,13 @@ from SimG4Core.CustomPhysics.Exotica_HSCP_SIM_cfi import customise
 #call to customisation function customise imported from SimG4Core.CustomPhysics.Exotica_HSCP_SIM_cfi
 process = customise(process)
 
-# Automatic addition of the customisation function from SimG4Core.CustomPhysics.genParticlePlusGeant
-from SimG4Core.CustomPhysics.genParticlePlusGeant import customizeKeep,customizeProduce 
+# Automatic addition of the customisation function from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
+from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi import customizeKeep,customizeProduce 
 
-#call to customisation function customizeKeep imported from SimG4Core.CustomPhysics.genParticlePlusGeant
+#call to customisation function customizeKeep imported from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
 process = customizeKeep(process)
 
-#call to customisation function customizeProduce imported from SimG4Core.CustomPhysics.genParticlePlusGeant
+#call to customisation function customizeProduce imported from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
 process = customizeProduce(process)
 
 # End of customisation functions

--- a/python/SUS-RunIISummer20UL18wmLHEGEN-stau400_lsp1_ctau100mm_cfg.py
+++ b/python/SUS-RunIISummer20UL18wmLHEGEN-stau400_lsp1_ctau100mm_cfg.py
@@ -2,7 +2,7 @@
 # using: 
 # Revision: 1.19 
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
-# with command line options: Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stau400_lsp1_ctau100mm.py --python_filename /afs/cern.ch/work/m/myshched/GEN-STAU/LLSTauProduction20UL18_pythia_100cm/LLSTauProduction/script/../python/SUS-RunIISummer20UL18wmLHEGEN-stau400_lsp1_ctau100mm_cfg.py --eventcontent RAWSIM --outputCommand keep *_genParticlePlusGeant_*_* --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/Exotica_HSCP_SIM_cfi.customise,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce --datatier GEN-SIM --fileout file:SUS-RunIISummer20UL18wmLHEGEN-LLStau.root --conditions 106X_upgrade2018_realistic_v11_L1v1 --beamspot Realistic25ns13TeVEarly2018Collision --customise_commands process.RandomNumberGeneratorService.externalLHEProducer.initialSeed=int(1)\nprocess.source.numberEventsInLuminosityBlock=cms.untracked.uint32(100) --step GEN,SIM --geometry DB:Extended --era Run2_2018 --no_exec --mc -n 20
+# with command line options: Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stau400_lsp1_ctau100mm.py --python_filename /afs/cern.ch/work/s/sobhatta/private/LongLivedStaus/test_forMCrequest_2/LLSTauProduction/script/../python/SUS-RunIISummer20UL18wmLHEGEN-stau400_lsp1_ctau100mm_cfg.py --eventcontent RAWSIM --outputCommand keep *_genParticlePlusGeant_*_*,keep *_packedGenParticlePlusGeant_*_*,keep *_prunedGenParticlePlusGeant_*_* --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/Exotica_HSCP_SIM_cfi.customise,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeKeep,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeProduce --datatier GEN-SIM --fileout file:SUS-RunIISummer20UL18wmLHEGEN-LLStau.root --conditions 106X_upgrade2018_realistic_v11_L1v1 --beamspot Realistic25ns13TeVEarly2018Collision --customise_commands process.RandomNumberGeneratorService.externalLHEProducer.initialSeed=int(1)\nprocess.source.numberEventsInLuminosityBlock=cms.untracked.uint32(100) --step GEN,SIM --geometry DB:Extended --era Run2_2018 --no_exec --mc -n 20
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
@@ -69,6 +69,8 @@ process.genstepfilter.triggerConditions=cms.vstring("generation_step")
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '106X_upgrade2018_realistic_v11_L1v1', '')
 process.RAWSIMoutput.outputCommands.append('keep *_genParticlePlusGeant_*_*')
+process.RAWSIMoutput.outputCommands.append('keep *_packedGenParticlePlusGeant_*_*')
+process.RAWSIMoutput.outputCommands.append('keep *_prunedGenParticlePlusGeant_*_*')
 
 process.generator = cms.EDFilter("Pythia8GeneratorFilter",
     ConfigDescription = cms.string('TStauStauLL_400_1_100.000000'),
@@ -134,7 +136,6 @@ process.generator = cms.EDFilter("Pythia8GeneratorFilter",
     ),
     SLHATableForPythia8 = cms.string('\nBLOCK MASS  # Mass Spectrum\n# PDG code           mass       particle\n   1000001     1.00000000E+05   # ~d_L\n   2000001     1.00000000E+05   # ~d_R\n   1000002     1.00000000E+05   # ~u_L\n   2000002     1.00000000E+05   # ~u_R\n   1000003     1.00000000E+05   # ~s_L\n   2000003     1.00000000E+05   # ~s_R\n   1000004     1.00000000E+05   # ~c_L\n   2000004     1.00000000E+05   # ~c_R\n   1000005     1.00000000E+05   # ~b_1\n   2000005     1.00000000E+05   # ~b_2\n   1000006     1.00000000E+05   # ~t_1\n   2000006     1.00000000E+05   # ~t_2\n   1000011     1.00000000E+05   # ~e_L\n   2000011     1.00000000E+05   # ~e_R\n   1000012     1.00000000E+05   # ~nu_eL\n   1000013     1.00000000E+05   # ~mu_L\n   2000013     1.00000000E+05   # ~mu_R\n   1000014     1.00000000E+05   # ~nu_muL\n   1000015     4.000000e+02          # ~tau_1\n   2000015     1.00000000E+05   # ~tau_2\n   1000016     1.00000000E+05   # ~nu_tauL\n   1000021     1.00000000E+05   # ~g\n   1000022     1.000000e+00           # ~chi_10\n   1000023     1.00000000E+05   # ~chi_20\n   1000025     1.00000000E+05   # ~chi_30\n   1000035     1.00000000E+05   # ~chi_40\n   1000024     1.00000000E+05   # ~chi_1+\n   1000037     1.00000000E+05   # ~chi_2+\n\n# DECAY TABLE\n#         PDG            Width\nDECAY   1000001     0.00000000E+00   # sdown_L decays\nDECAY   2000001     0.00000000E+00   # sdown_R decays\nDECAY   1000002     0.00000000E+00   # sup_L decays\nDECAY   2000002     0.00000000E+00   # sup_R decays\nDECAY   1000003     0.00000000E+00   # sstrange_L decays\nDECAY   2000003     0.00000000E+00   # sstrange_R decays\nDECAY   1000004     0.00000000E+00   # scharm_L decays\nDECAY   2000004     0.00000000E+00   # scharm_R decays\nDECAY   1000005     0.00000000E+00   # sbottom1 decays\nDECAY   2000005     0.00000000E+00   # sbottom2 decays\nDECAY   1000006     0.00000000E+00   # stop1 decays\nDECAY   2000006     0.00000000E+00   # stop2 decays\nDECAY   1000011     0.00000000E+00   # selectron_L decays\nDECAY   2000011     0.00000000E+00   # selectron_R decays\nDECAY   1000012     0.0000000E+00    # snu_elL decays\nDECAY   1000013     0.00000000E+00   # smuon_L decays\nDECAY   2000013     0.00000000E+00   # smuon_R decays\nDECAY   1000014     0.00000000E+00   # snu_muL decays\nDECAY   1000015     1.973270e-15           # stau_1 decays\n    1.00000000E+00    2    1000022    15\nDECAY   2000015     0.00000000E+00   # stau_2 decays\nDECAY   1000016     0.00000000E+00   # snu_tauL decays\nDECAY   1000021     0.00000000E+00   # gluino decays\nDECAY   1000022     0.00000000E+00   # neutralino1 decays\nDECAY   1000023     0.00000000E+00   # neutralino2 decays\nDECAY   1000024     0.00000000E+00   # chargino1+ decays\nDECAY   1000025     0.00000000E+00   # neutralino3 decays\nDECAY   1000035     0.00000000E+00   # neutralino4 decays\nDECAY   1000037     0.00000000E+00   # chargino2+ decays\n'),
     comEnergy = cms.double(13000.0),
-    crossSection = cms.untracked.double(0.001859),
     filterEfficiency = cms.untracked.double(1.0),
     hscpFlavor = cms.untracked.string('stau'),
     massPoint = cms.untracked.int32(400),
@@ -176,13 +177,13 @@ from SimG4Core.CustomPhysics.Exotica_HSCP_SIM_cfi import customise
 #call to customisation function customise imported from SimG4Core.CustomPhysics.Exotica_HSCP_SIM_cfi
 process = customise(process)
 
-# Automatic addition of the customisation function from SimG4Core.CustomPhysics.genParticlePlusGeant
-from SimG4Core.CustomPhysics.genParticlePlusGeant import customizeKeep,customizeProduce 
+# Automatic addition of the customisation function from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
+from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi import customizeKeep,customizeProduce 
 
-#call to customisation function customizeKeep imported from SimG4Core.CustomPhysics.genParticlePlusGeant
+#call to customisation function customizeKeep imported from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
 process = customizeKeep(process)
 
-#call to customisation function customizeProduce imported from SimG4Core.CustomPhysics.genParticlePlusGeant
+#call to customisation function customizeProduce imported from SimG4Core.CustomPhysics.GenPlusSimParticles_cfi
 process = customizeProduce(process)
 
 # End of customisation functions

--- a/script/CreateDrivers.sh
+++ b/script/CreateDrivers.sh
@@ -14,17 +14,18 @@ source /cvmfs/cms.cern.ch/cmsset_default.sh
 export CMSSW_GIT_REFERENCE=/cvmfs/cms.cern.ch/cmssw.git.daily
 export SCRAM_ARCH=slc7_amd64_gcc700
 
-if [ -r ${ENV_PATH}/CMSSW_10_6_27/src ] ; then
-  echo "CMSSW_10_6_27 exists"
-  cd ${ENV_PATH}/CMSSW_10_6_27/src
+if [ -r ${ENV_PATH}/CMSSW_10_6_30_patch1/src ] ; then
+  echo "CMSSW_10_6_30_patch1 exists"
+  cd ${ENV_PATH}/CMSSW_10_6_30_patch1/src
   eval `scramv1 runtime -sh` # the same as cmsenv
   cd -
 else
-  echo "CMSSW_10_6_27 does not exist"
+  echo "CMSSW_10_6_30_patch1 does not exist"
   exit 1
 fi
 
 STAU_MASS_POINTS=(100 250 400) #GeV
+#STAU_MASS_POINTS=(250) #GeV
 LSP_MASS_POINTS=(1) #GeV
 CTAU_POINTS=(100) #mm
 
@@ -36,8 +37,8 @@ echo "Creating cmsDrive for GEN-SIM, Create for mstau:${MASS}, mlsp:${LSP}, ctau
 cmsDriver.py Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stau${MASS}_lsp${LSP}_ctau${CTAU}mm.py \
   --python_filename ${OUTDIR}/python/SUS-RunIISummer20UL18wmLHEGEN-stau${MASS}_lsp${LSP}_ctau${CTAU}mm_cfg.py \
   --eventcontent RAWSIM \
-  --outputCommand 'keep *_genParticlePlusGeant_*_*' \
-  --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/Exotica_HSCP_SIM_cfi.customise,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce \
+  --outputCommand 'keep *_genParticlePlusGeant_*_*,keep *_packedGenParticlePlusGeant_*_*,keep *_prunedGenParticlePlusGeant_*_*' \
+  --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/Exotica_HSCP_SIM_cfi.customise,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeKeep,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeProduce \
   --datatier GEN-SIM \
   --fileout file:SUS-RunIISummer20UL18wmLHEGEN-LLStau.root \
   --conditions 106X_upgrade2018_realistic_v11_L1v1 \
@@ -52,21 +53,21 @@ done
 done
 done
 
-if [ -r ${ENV_PATH}/CMSSW_10_6_27/src ] ; then
-  echo "CMSSW_10_6_27 exists"
-  cd ${ENV_PATH}/CMSSW_10_6_27/src
+if [ -r ${ENV_PATH}/CMSSW_10_6_30_patch1/src ] ; then
+  echo "CMSSW_10_6_30_patch1 exists"
+  cd ${ENV_PATH}/CMSSW_10_6_30_patch1/src
   eval `scramv1 runtime -sh` # the same as cmsenv
   cd -
 else
-  echo "CMSSW_10_6_27 does not exist"
+  echo "CMSSW_10_6_30_patch1 does not exist"
   exit 1
 fi
 
 echo "Creating cmsDrive for PREMIXRAW"
 cmsDriver.py  --python_filename ${OUTDIR}/python/SUS-RunIISummer20UL18DIGIPremix_cfg.py \
   --eventcontent PREMIXRAW \
-  --outputCommand 'keep *_genParticlePlusGeant_*_*' \
-  --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce \
+  --outputCommand 'keep *_genParticlePlusGeant_*_*,keep *_packedGenParticlePlusGeant_*_*,keep *_prunedGenParticlePlusGeant_*_*' \
+  --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeKeep,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeProduce \
   --datatier GEN-SIM-RAW \
   --fileout file:SUS-RunIIAutumn18DRPremix-LLStau.root \
   --pileup_input "dbs:/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL18_106X_upgrade2018_realistic_v11_L1v1-v2/PREMIX" \
@@ -91,8 +92,8 @@ fi
 echo "Creating cmsDrive for HLT"
 cmsDriver.py  --python_filename ${OUTDIR}/python/SUS-RunIISummer20UL18HLT_cfg.py \
   --eventcontent RAWSIM \
-  --outputCommand 'keep *_genParticlePlusGeant_*_*' \
-  --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce \
+  --outputCommand 'keep *_genParticlePlusGeant_*_*,keep *_packedGenParticlePlusGeant_*_*,keep *_prunedGenParticlePlusGeant_*_*' \
+  --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeKeep,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeProduce \
   --datatier GEN-SIM-RAW \
   --fileout file:SUS-RunIISummer20UL18HLT-LLStau.root \
   --conditions 102X_upgrade2018_realistic_v15 \
@@ -102,13 +103,13 @@ cmsDriver.py  --python_filename ${OUTDIR}/python/SUS-RunIISummer20UL18HLT_cfg.py
   --filein file:SUS-RunIIAutumn18DRPremix-LLStau.root \
   --era Run2_2018 --no_exec --mc -n 20|| exit $? ;
 
-if [ -r ${ENV_PATH}/CMSSW_10_6_27/src ] ; then
-  echo "CMSSW_10_6_27 exists"
-  cd ${ENV_PATH}/CMSSW_10_6_27/src
+if [ -r ${ENV_PATH}/CMSSW_10_6_30_patch1/src ] ; then
+  echo "CMSSW_10_6_30_patch1 exists"
+  cd ${ENV_PATH}/CMSSW_10_6_30_patch1/src
   eval `scramv1 runtime -sh` # the same as cmsenv
   cd -
 else
-  echo "CMSSW_10_6_27 does not exist"
+  echo "CMSSW_10_6_30_patch1 does not exist"
   exit 1
 fi
 
@@ -117,8 +118,8 @@ echo "Creating cmsDrive for AOD"
 # cmsDriver command
 cmsDriver.py  --python_filename ${OUTDIR}/python/SUS-RunIISummer20UL18RECO_cfg.py\
   --eventcontent AODSIM \
-  --outputCommand 'keep *_genParticlePlusGeant_*_*' \
-  --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce \
+  --outputCommand 'keep *_genParticlePlusGeant_*_*,keep *_packedGenParticlePlusGeant_*_*,keep *_prunedGenParticlePlusGeant_*_*' \
+  --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeKeep,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeProduce \
   --datatier AODSIM \
   --fileout file:SUS-RunIISummer20UL18RECO-LLStau.root \
   --conditions 106X_upgrade2018_realistic_v11_L1v1 \
@@ -128,21 +129,21 @@ cmsDriver.py  --python_filename ${OUTDIR}/python/SUS-RunIISummer20UL18RECO_cfg.p
   --era Run2_2018 --runUnscheduled \
   --no_exec --mc -n 20 || exit $? ;
 
-if [ -r ${ENV_PATH}/CMSSW_10_6_27/src ] ; then
-  echo "CMSSW_10_6_27 exists"
-  cd ${ENV_PATH}/CMSSW_10_6_27/src
+if [ -r ${ENV_PATH}/CMSSW_10_6_30_patch1/src ] ; then
+  echo "CMSSW_10_6_30_patch1 exists"
+  cd ${ENV_PATH}/CMSSW_10_6_30_patch1/src
   eval `scramv1 runtime -sh` # the same as cmsenv
   cd -
 else
-  echo "CMSSW_10_6_27 does not exist"
+  echo "CMSSW_10_6_30_patch1 does not exist"
   exit 1
 fi
 
 echo "Creating cmsDrive for MiniAOD"
 cmsDriver.py  --python_filename ${OUTDIR}/python/SUS-RunIISummer20UL18MiniAODv2_cfg.py \
 --eventcontent MINIAODSIM \
---outputCommand 'keep *_genParticlePlusGeant_*_*' \
---customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce \
+--outputCommand 'keep *_genParticlePlusGeant_*_*,keep *_packedGenParticlePlusGeant_*_*,keep *_prunedGenParticlePlusGeant_*_*' \
+--customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeKeep,SimG4Core/CustomPhysics/GenPlusSimParticles_cfi.customizeProduce \
 --datatier MINIAODSIM \
 --fileout file:SUS-RunIISummer20UL18MiniAODv2-LLStau.root \
 --conditions 106X_upgrade2018_realistic_v16_L1v1 \

--- a/script/CreateDrivers_old1.sh
+++ b/script/CreateDrivers_old1.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+# ENV_PATH=/afs/cern.ch/user/m/myshched/STauGENProduction
+
+ABS_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+OUTDIR=${ABS_PATH}/..
+
+ENV_PATH=${ABS_PATH}/../envs
+
+echo "OUTDIR: ${OUTDIR}"
+echo "ENV_PATH: ${ENV_PATH}"
+
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+export CMSSW_GIT_REFERENCE=/cvmfs/cms.cern.ch/cmssw.git.daily
+export SCRAM_ARCH=slc7_amd64_gcc700
+
+if [ -r ${ENV_PATH}/CMSSW_10_6_30_patch1/src ] ; then
+  echo "CMSSW_10_6_30_patch1 exists"
+  cd ${ENV_PATH}/CMSSW_10_6_30_patch1/src
+  eval `scramv1 runtime -sh` # the same as cmsenv
+  cd -
+else
+  echo "CMSSW_10_6_30_patch1 does not exist"
+  exit 1
+fi
+
+STAU_MASS_POINTS=(100 250 400) #GeV
+#STAU_MASS_POINTS=(250) #GeV
+LSP_MASS_POINTS=(1) #GeV
+CTAU_POINTS=(100) #mm
+
+for MASS in ${STAU_MASS_POINTS[@]}; do
+for LSP in ${LSP_MASS_POINTS[@]}; do
+for CTAU in ${CTAU_POINTS[@]}; do
+
+echo "Creating cmsDrive for GEN-SIM, Create for mstau:${MASS}, mlsp:${LSP}, ctau:${CTAU}mm"
+cmsDriver.py Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stau${MASS}_lsp${LSP}_ctau${CTAU}mm.py \
+  --python_filename ${OUTDIR}/python/SUS-RunIISummer20UL18wmLHEGEN-stau${MASS}_lsp${LSP}_ctau${CTAU}mm_cfg.py \
+  --eventcontent RAWSIM \
+  --outputCommand 'keep *_genParticlePlusGeant_*_*' \
+  --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/Exotica_HSCP_SIM_cfi.customise,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce \
+  --datatier GEN-SIM \
+  --fileout file:SUS-RunIISummer20UL18wmLHEGEN-LLStau.root \
+  --conditions 106X_upgrade2018_realistic_v11_L1v1 \
+  --beamspot Realistic25ns13TeVEarly2018Collision \
+  --customise_commands "process.RandomNumberGeneratorService.externalLHEProducer.initialSeed=int(1)\nprocess.source.numberEventsInLuminosityBlock=cms.untracked.uint32(100)" \
+  --step GEN,SIM \
+  --geometry DB:Extended \
+  --era Run2_2018 \
+  --no_exec --mc -n 20 || exit $? ;
+
+done
+done
+done
+
+if [ -r ${ENV_PATH}/CMSSW_10_6_30_patch1/src ] ; then
+  echo "CMSSW_10_6_30_patch1 exists"
+  cd ${ENV_PATH}/CMSSW_10_6_30_patch1/src
+  eval `scramv1 runtime -sh` # the same as cmsenv
+  cd -
+else
+  echo "CMSSW_10_6_30_patch1 does not exist"
+  exit 1
+fi
+
+echo "Creating cmsDrive for PREMIXRAW"
+cmsDriver.py  --python_filename ${OUTDIR}/python/SUS-RunIISummer20UL18DIGIPremix_cfg.py \
+  --eventcontent PREMIXRAW \
+  --outputCommand 'keep *_genParticlePlusGeant_*_*' \
+  --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce \
+  --datatier GEN-SIM-RAW \
+  --fileout file:SUS-RunIIAutumn18DRPremix-LLStau.root \
+  --pileup_input "dbs:/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL18_106X_upgrade2018_realistic_v11_L1v1-v2/PREMIX" \
+  --conditions 106X_upgrade2018_realistic_v11_L1v1 \
+  --step DIGI,DATAMIX,L1,DIGI2RAW \
+  --procModifiers premix_stage2 \
+  --geometry DB:Extended \
+  --filein file:SUS-RunIISummer20UL18wmLHEGEN-LLStau.root \
+  --datamix PreMix --era Run2_2018 \
+  --no_exec --mc  -n 20 || exit $? ;
+
+if [ -r ${ENV_PATH}/CMSSW_10_2_16_UL/src ] ; then
+  echo "CMSSW_10_2_16_UL exists"
+  cd ${ENV_PATH}/CMSSW_10_2_16_UL/src
+  eval `scramv1 runtime -sh` # the same as cmsenv
+  cd -
+else
+  echo "CMSSW_10_2_16_UL does not exist"
+  exit 1
+fi
+
+echo "Creating cmsDrive for HLT"
+cmsDriver.py  --python_filename ${OUTDIR}/python/SUS-RunIISummer20UL18HLT_cfg.py \
+  --eventcontent RAWSIM \
+  --outputCommand 'keep *_genParticlePlusGeant_*_*' \
+  --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce \
+  --datatier GEN-SIM-RAW \
+  --fileout file:SUS-RunIISummer20UL18HLT-LLStau.root \
+  --conditions 102X_upgrade2018_realistic_v15 \
+  --customise_commands 'process.source.bypassVersionCheck = cms.untracked.bool(True)' \
+  --step HLT:2018v32 \
+  --geometry DB:Extended \
+  --filein file:SUS-RunIIAutumn18DRPremix-LLStau.root \
+  --era Run2_2018 --no_exec --mc -n 20|| exit $? ;
+
+if [ -r ${ENV_PATH}/CMSSW_10_6_30_patch1/src ] ; then
+  echo "CMSSW_10_6_30_patch1 exists"
+  cd ${ENV_PATH}/CMSSW_10_6_30_patch1/src
+  eval `scramv1 runtime -sh` # the same as cmsenv
+  cd -
+else
+  echo "CMSSW_10_6_30_patch1 does not exist"
+  exit 1
+fi
+
+
+echo "Creating cmsDrive for AOD"
+# cmsDriver command
+cmsDriver.py  --python_filename ${OUTDIR}/python/SUS-RunIISummer20UL18RECO_cfg.py\
+  --eventcontent AODSIM \
+  --outputCommand 'keep *_genParticlePlusGeant_*_*' \
+  --customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce \
+  --datatier AODSIM \
+  --fileout file:SUS-RunIISummer20UL18RECO-LLStau.root \
+  --conditions 106X_upgrade2018_realistic_v11_L1v1 \
+  --step RAW2DIGI,L1Reco,RECO,RECOSIM,EI \
+  --geometry DB:Extended \
+  --filein file:SUS-RunIISummer20UL18HLT-LLStau.root \
+  --era Run2_2018 --runUnscheduled \
+  --no_exec --mc -n 20 || exit $? ;
+
+if [ -r ${ENV_PATH}/CMSSW_10_6_30_patch1/src ] ; then
+  echo "CMSSW_10_6_30_patch1 exists"
+  cd ${ENV_PATH}/CMSSW_10_6_30_patch1/src
+  eval `scramv1 runtime -sh` # the same as cmsenv
+  cd -
+else
+  echo "CMSSW_10_6_30_patch1 does not exist"
+  exit 1
+fi
+
+echo "Creating cmsDrive for MiniAOD"
+cmsDriver.py  --python_filename ${OUTDIR}/python/SUS-RunIISummer20UL18MiniAODv2_cfg.py \
+--eventcontent MINIAODSIM \
+--outputCommand 'keep *_genParticlePlusGeant_*_*' \
+--customise Configuration/DataProcessing/Utils.addMonitoring,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeKeep,SimG4Core/CustomPhysics/genParticlePlusGeant.customizeProduce \
+--datatier MINIAODSIM \
+--fileout file:SUS-RunIISummer20UL18MiniAODv2-LLStau.root \
+--conditions 106X_upgrade2018_realistic_v16_L1v1 \
+--step PAT --procModifiers run2_miniAOD_UL \
+--geometry DB:Extended \
+--filein file:SUS-RunIISummer20UL18RECO-LLStau.root\
+ --era Run2_2018 --runUnscheduled \
+ --no_exec --mc -n 20 || exit $? ;

--- a/script/CreateEnv.sh
+++ b/script/CreateEnv.sh
@@ -13,48 +13,51 @@ echo "Creating environment for RAWSIM"
 cd $ENV_PATH
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 export SCRAM_ARCH=slc7_amd64_gcc700
-if [ -r ${ENV_PATH}/CMSSW_10_6_27/src ] ; then
-  echo release CMSSW_10_6_27 already exists
+if [ -r ${ENV_PATH}/CMSSW_10_6_30_patch1/src ] ; then
+  echo release CMSSW_10_6_30_patch1 already exists
 else
   cd ${ENV_PATH}
-  scram p CMSSW CMSSW_10_6_27
+  scram p CMSSW CMSSW_10_6_30_patch1
 
-  cd ${ENV_PATH}/CMSSW_10_6_27/src
+  cd ${ENV_PATH}/CMSSW_10_6_30_patch1/src
   eval `scramv1 runtime -sh`
-  git cms-addpkg SimG4Core/CustomPhysics/
+  #git cms-addpkg SimG4Core/CustomPhysics
   # git pull my-cmssw CMSSW_10_6_X # fetch and merge fix of HepMC stau handling
-  git remote add fix_pr git@github.com:shedprog/cmssw.git
-  git fetch fix_pr CMSSW_10_6_X
-  git checkout fix_pr/CMSSW_10_6_X
-  git cms-addpkg SimG4Core/Generators
+  #git remote add fix_pr git@github.com:shedprog/cmssw.git
+  #git fetch fix_pr CMSSW_10_6_X
+  #git checkout fix_pr/CMSSW_10_6_X
+  #git cms-addpkg SimG4Core/Generators
 fi
 
 
 # Step 1: Copy test particle files
-mkdir -p ${ENV_PATH}/CMSSW_10_6_27/src/data
-cp ${OUTDIR}/Configuration/ParticleFiles/*.txt ${ENV_PATH}/CMSSW_10_6_27/src/data
+mkdir -p ${ENV_PATH}/CMSSW_10_6_30_patch1/src/data
+cp ${OUTDIR}/Configuration/ParticleFiles/*.txt ${ENV_PATH}/CMSSW_10_6_30_patch1/src/data
 
-cd ${ENV_PATH}/CMSSW_10_6_27/src
+cd ${ENV_PATH}/CMSSW_10_6_30_patch1/src
 
 # Step 2: Copy genParticlePlusGeant
-cp -f ${OUTDIR}/Configuration/genParticlePlusGeant.py ${ENV_PATH}/CMSSW_10_6_27/src/SimG4Core/CustomPhysics/python/genParticlePlusGeant.py
+#cp -f ${OUTDIR}/Configuration/genParticlePlusGeant.py ${ENV_PATH}/CMSSW_10_6_30_patch1/src/SimG4Core/CustomPhysics/python/genParticlePlusGeant.py
 
 # Step 3: Copy HSCP file
-cp -f ${OUTDIR}/Configuration/Exotica_HSCP_SIM_cfi.py ${ENV_PATH}/CMSSW_10_6_27/src/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
+#cp -f ${OUTDIR}/Configuration/Exotica_HSCP_SIM_cfi.py ${ENV_PATH}/CMSSW_10_6_30_patch1/src/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
 
 # Step 3: Copy fragment-file
 source ${ABS_PATH}/CrossSection.sh
-mkdir -p ${ENV_PATH}/CMSSW_10_6_27/src/Configuration/GenProduction/python
+mkdir -p ${ENV_PATH}/CMSSW_10_6_30_patch1/src/Configuration/GenProduction/python
 STAU_MASS_POINTS=(100 250 400) #GeV
+#STAU_MASS_POINTS=(250) #GeV
 LSP_MASS_POINTS=(1) #GeV
 CTAU_POINTS=(100) #mm
 for MASS in ${STAU_MASS_POINTS[@]}; do
 for LSP in ${LSP_MASS_POINTS[@]}; do
 for CTAU in ${CTAU_POINTS[@]}; do
-  set -e; XSEC=$(GET_XSEC $MASS); set +e
-  echo "Create fragment mstau:${MASS}, mlsp:${LSP}, ctau:${CTAU}mm, XSEC: ${XSEC}"
-  sed "s/STAU_MASS_XXX/$MASS/" ${OUTDIR}/Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stauXXX_lspXXX_ctauXXXmm.py | sed "s/LSP_MASS_XXX/$LSP/" | sed "s/XSEC_XXX/$XSEC/" | sed "s/CTAU_XXX/$CTAU/" > ${ENV_PATH}/CMSSW_10_6_27/src/Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stau${MASS}_lsp${LSP}_ctau${CTAU}mm.py
-  [ -s ${ENV_PATH}/CMSSW_10_6_27/src/Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stau${MASS}_lsp${LSP}_ctau${CTAU}mm.py ] || exit $?;
+  #set -e; XSEC=$(GET_XSEC $MASS); set +e
+  #echo "Create fragment mstau:${MASS}, mlsp:${LSP}, ctau:${CTAU}mm, XSEC: ${XSEC}"
+  echo "Create fragment mstau:${MASS}, mlsp:${LSP}, ctau:${CTAU}mm"
+  #sed "s/STAU_MASS_XXX/$MASS/" ${OUTDIR}/Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stauXXX_lspXXX_ctauXXXmm.py | sed "s/LSP_MASS_XXX/$LSP/" | sed "s/XSEC_XXX/$XSEC/" | sed "s/CTAU_XXX/$CTAU/" > ${ENV_PATH}/CMSSW_10_6_30_patch1/src/Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stau${MASS}_lsp${LSP}_ctau${CTAU}mm.py
+  sed "s/STAU_MASS_XXX/$MASS/" ${OUTDIR}/Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stauXXX_lspXXX_ctauXXXmm.py | sed "s/LSP_MASS_XXX/$LSP/" | sed "s/CTAU_XXX/$CTAU/" > ${ENV_PATH}/CMSSW_10_6_30_patch1/src/Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stau${MASS}_lsp${LSP}_ctau${CTAU}mm.py
+  [ -s ${ENV_PATH}/CMSSW_10_6_30_patch1/src/Configuration/GenProduction/python/SUS-RunIISummer20UL18wmLHEGEN-fragment-stau${MASS}_lsp${LSP}_ctau${CTAU}mm.py ] || exit $?;
 done
 done
 done
@@ -70,15 +73,15 @@ else
 
   cd ${ENV_PATH}/CMSSW_10_2_16_UL/src
   eval `scramv1 runtime -sh`
-  git cms-addpkg SimG4Core/CustomPhysics/
+  #git cms-addpkg SimG4Core/CustomPhysics
 fi
 cd ${ENV_PATH}/CMSSW_10_2_16_UL/src
 
 # Step 2: Copy genParticlePlusGeant
-cp -f ${OUTDIR}/Configuration/genParticlePlusGeant.py ${ENV_PATH}/CMSSW_10_2_16_UL/src/SimG4Core/CustomPhysics/python/genParticlePlusGeant.py
+#cp -f ${OUTDIR}/Configuration/genParticlePlusGeant.py ${ENV_PATH}/CMSSW_10_2_16_UL/src/SimG4Core/CustomPhysics/python/genParticlePlusGeant.py
 
 # Step 3: Copy HSCP file
-cp -f ${OUTDIR}/Configuration/Exotica_HSCP_SIM_cfi.py ${ENV_PATH}/CMSSW_10_2_16_UL/src/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
+#cp -f ${OUTDIR}/Configuration/Exotica_HSCP_SIM_cfi.py ${ENV_PATH}/CMSSW_10_2_16_UL/src/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
 
 eval `scram runtime -sh`
 scram b

--- a/script/TestProdLocal.sh
+++ b/script/TestProdLocal.sh
@@ -11,13 +11,13 @@ source /cvmfs/cms.cern.ch/cmsset_default.sh
 export CMSSW_GIT_REFERENCE=/cvmfs/cms.cern.ch/cmssw.git.daily
 export SCRAM_ARCH=slc7_amd64_gcc700
 
-if [ -r ${ENV_PATH}/CMSSW_10_6_27/src ] ; then
-  echo "CMSSW_10_6_27 exists"
-  cd ${ENV_PATH}/CMSSW_10_6_27/src
+if [ -r ${ENV_PATH}/CMSSW_10_6_30_patch1/src ] ; then
+  echo "CMSSW_10_6_30_patch1 exists"
+  cd ${ENV_PATH}/CMSSW_10_6_30_patch1/src
   eval `scramv1 runtime -sh` # the same as cmsenv
   cd -
 else
-  echo "CMSSW_10_6_27 does not exist"
+  echo "CMSSW_10_6_30_patch1 does not exist"
   exit 1
 fi
 
@@ -37,13 +37,13 @@ fi
 
 cmsRun -e -j SUS-RunIISummer20UL18HLT_report.xml ${ABS_PATH}/../python/SUS-RunIISummer20UL18HLT_cfg.py || exit $? ;
 
-if [ -r ${ENV_PATH}/CMSSW_10_6_27/src ] ; then
-  echo "CMSSW_10_6_27 exists"
-  cd ${ENV_PATH}/CMSSW_10_6_27/src
+if [ -r ${ENV_PATH}/CMSSW_10_6_30_patch1/src ] ; then
+  echo "CMSSW_10_6_30_patch1 exists"
+  cd ${ENV_PATH}/CMSSW_10_6_30_patch1/src
   eval `scramv1 runtime -sh` # the same as cmsenv
   cd -
 else
-  echo "CMSSW_10_6_27 does not exist"
+  echo "CMSSW_10_6_30_patch1 does not exist"
   exit 1
 fi
 


### PR DESCRIPTION
1. Removed crossSection from fragment -- no longer required.
2. Updated to 10_6_30_patch1
3. Removed the command to copy the genParticlesPlusGeant and HSCP config files -- no longer required.